### PR TITLE
Solve renaming issues with special characters

### DIFF
--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -18,6 +18,18 @@ export class NAVObject {
     private _workSpaceSettings: Settings;
     private _objectFileNamePattern: string;
 
+    // Windows chars not allowed in filenames or paths (includes Linux):
+    // < (less than)
+    // > (greater than)
+    // : (colon - sometimes works, but is actually NTFS Alternate Data Streams)
+    // " (double quote)
+    // / (forward slash)
+    // \ (backslash)
+    // | (vertical bar or pipe)
+    // ? (question mark)
+    // * (asterisk)
+    private prohibitedFilenameCharsPattern :string = '<>:"/\\\\|\\?\\*';
+
     constructor(navObject: string, workSpaceSettings: Settings, navObjectFileBaseName: string);
     constructor(navObject: any, workSpaceSettings: Settings, navObjectFileBaseName?: string) {
         this.NAVObjectText = navObject
@@ -34,23 +46,29 @@ export class NAVObject {
     get objectNameFixed(): string {
         let objectNameFixed = this.objectName.trim().toString();
         objectNameFixed = this.AddPrefixAndSuffixToObjectNameFixed(this.objectName);
-
-        return objectNameFixed.replace(/[^ 0-9a-zA-Z._&-]/g, '_');
+        return objectNameFixed;
+    }
+    get objectNameFixedForFileName(): string {
+        let objectNameFixed = this.objectNameFixed;
+        return objectNameFixed.replace(new RegExp(`[${this.prohibitedFilenameCharsPattern}]`,'g'), '_');
     }
     get objectNameFixedShort(): string {
         return StringFunctions.removeAllButAlfaNumeric(this.objectNameFixed);
     }
     get extendedObjectNameFixed(): string {
         let extendedObjectName = this.extendedObjectName.trim().toString();
-
-        return extendedObjectName.replace(/[^ 0-9a-zA-Z._&-]/g, '_');
+        return extendedObjectName;
+    }
+    get extendedObjectNameFixedForFileName(): string {
+        let extendedObjectName = this.extendedObjectNameFixed;
+        return extendedObjectName.replace(new RegExp(`[${this.prohibitedFilenameCharsPattern}]`,'g'), '_');
     }
     get extendedObjectNameFixedShort(): string {
         return StringFunctions.removeAllButAlfaNumeric(this.extendedObjectNameFixed);
     }
     get NAVObjectTextFixed(): string {
         let NAVObjectTextFixed = this.NAVObjectText;
-        NAVObjectTextFixed = this.updateObjectNameInObjectText(NAVObjectTextFixed);
+        NAVObjectTextFixed = this.updateObjectNameInObjectText(NAVObjectTextFixed); 
         NAVObjectTextFixed = this.AddPrefixToActions(NAVObjectTextFixed);
         NAVObjectTextFixed = this.AddPrefixToFields(NAVObjectTextFixed);
 
@@ -67,9 +85,9 @@ export class NAVObject {
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectTypeShort>', this.objectTypeShort);
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectTypeShortUpper>', this.objectTypeShort.toUpperCase());
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectId>', this.objectId);
-        objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectName>', this.objectNameFixed);
+        objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectName>', this.objectNameFixedForFileName);
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectNameShort>', this.objectNameFixedShort);
-        objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<BaseName>', this.extendedObjectNameFixed);
+        objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<BaseName>', this.extendedObjectNameFixedForFileName);
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<BaseNameShort>', this.extendedObjectNameFixedShort);
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<BaseId>', this.extendedObjectId);
 
@@ -99,6 +117,8 @@ export class NAVObject {
         this.objectName = '';
         this.extendedObjectName = '';
         this.extendedObjectId = '';
+        var ObjectNamePattern = '"[\\w\\(\\)\\.-_ /&%]*"';
+        var ObjectNameNoQuotesPattern = '[\\w]*';
 
         if (!ObjectTypeArr) { return null }
 
@@ -112,7 +132,7 @@ export class NAVObject {
                 case 'table':
                 case 'xmlport': {
 
-                    var patternObject = new RegExp('(\\w+)( +[0-9]+)( +"?[ a-zA-Z0-9._/&-]+"?)');
+                    var patternObject = new RegExp(`(\\w+) +([0-9]+) +(${ObjectNamePattern}|${ObjectNameNoQuotesPattern})`);
                     let currObject = this.NAVObjectText.match(patternObject);
 
                     this.objectType = currObject[1];
@@ -125,9 +145,8 @@ export class NAVObject {
                 }
                 case 'pageextension':
                 case 'tableextension': {
-                    var patternObject = new RegExp('(\\w+)( +[0-9]+)( +"?[ a-zA-Z0-9._&-]+\\/?[ a-zA-Z0-9._&-]+"?) +extends( +"?[ a-zA-Z0-9._&-]+\\/?[ a-zA-Z0-9._&-]+"?) ?(\\/\\/+ *)?([0-9]+)?');
+                    var patternObject = new RegExp(`(\\w+) +([0-9]+) +(${ObjectNamePattern}|${ObjectNameNoQuotesPattern}) +extends +(${ObjectNamePattern}|${ObjectNameNoQuotesPattern})\\s*(\\/\\/\\s*)?([0-9]+)?`);
                     let currObject = this.NAVObjectText.match(patternObject);
-
                     this.objectType = currObject[1];
                     this.objectId = currObject[2];
                     this.objectName = currObject[3];
@@ -207,13 +226,19 @@ export class NAVObject {
 
     private updateObjectNameInObjectText(objectText: string): string {
         if (!this.objectName) { return objectText };
-
+        var escapedObjectName = this.escapeRegExp(this.objectName);
+        var searchPattern = RegExp(escapedObjectName);
         if (objectText.indexOf("\"" + this.objectName + "\"") >= 0) {
-            return objectText.replace(this.objectName, this.objectNameFixed);
+            return objectText.replace(searchPattern, this.objectNameFixed);
         } else {
-            return objectText.replace(this.objectName, "\"" + this.objectNameFixed + "\"");
+            return objectText.replace(searchPattern, "\"" + this.objectNameFixed + "\"");
         }
     }
+
+    private escapeRegExp(str) {
+        // Ref. https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+        return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+      }
 
     private AddPrefixToActions(objectText: string): string {
         this.objectActions.forEach(action => {

--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -34,6 +34,7 @@ export class NAVObject {
     constructor(navObject: any, workSpaceSettings: Settings, navObjectFileBaseName?: string) {
         this.NAVObjectText = navObject
         this.objectFileName = navObjectFileBaseName
+        console.log(`Loading file "${this.objectFileName}"`);
 
         this._workSpaceSettings = workSpaceSettings;
 
@@ -117,7 +118,7 @@ export class NAVObject {
         this.objectName = '';
         this.extendedObjectName = '';
         this.extendedObjectId = '';
-        var ObjectNamePattern = '"[\\w\\(\\)\\.-_ /&%]*"';
+        var ObjectNamePattern = '"[\\w\\(\\)\\.\\-_ /&%]*"';
         var ObjectNameNoQuotesPattern = '[\\w]*';
 
         if (!ObjectTypeArr) { return null }


### PR DESCRIPTION
I got a lot of errors when using the renaming/reorganize feature on our solution. It seems as all comes down to issues with special characters.


Several issues that I'm trying to solve here:
1. Several special characters not supported
2. Object names is only surrounded with " if needed
3. Objects gets renamed if containing some illegal characters, even though only file needs that. I want object name to remain.

I've tried to solve above issues, and it now runs fine on my 600+ objects. I might have missed some special characters, but at least they only need to be added on one place now.

I have not changed the naming of profile and pagecustomization, since I had not test objects for those, but probably the same change could be done there.
