### PR TITLE
Another go on "Solve renaming issues with special characters"

### DIFF
--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -18,10 +18,23 @@ export class NAVObject {
     private _workSpaceSettings: Settings;
     private _objectFileNamePattern: string;
 
+    // Windows chars not allowed in filenames or paths (includes Linux):
+    // < (less than)
+    // > (greater than)
+    // : (colon - sometimes works, but is actually NTFS Alternate Data Streams)
+    // " (double quote)
+    // / (forward slash)
+    // \ (backslash)
+    // | (vertical bar or pipe)
+    // ? (question mark)
+    // * (asterisk)
+    private prohibitedFilenameCharsPattern :string = '<>:"/\\\\|\\?\\*';
+
     constructor(navObject: string, workSpaceSettings: Settings, navObjectFileBaseName: string);
     constructor(navObject: any, workSpaceSettings: Settings, navObjectFileBaseName?: string) {
         this.NAVObjectText = navObject
         this.objectFileName = navObjectFileBaseName
+        console.log(`Loading file "${this.objectFileName}"`);
 
         this._workSpaceSettings = workSpaceSettings;
 
@@ -34,23 +47,29 @@ export class NAVObject {
     get objectNameFixed(): string {
         let objectNameFixed = this.objectName.trim().toString();
         objectNameFixed = this.AddPrefixAndSuffixToObjectNameFixed(this.objectName);
-
-        return objectNameFixed.replace(/[^ 0-9a-zA-Z._&-]/g, '_');
+        return objectNameFixed;
+    }
+    get objectNameFixedForFileName(): string {
+        let objectNameFixed = this.objectNameFixed;
+        return objectNameFixed.replace(new RegExp(`[${this.prohibitedFilenameCharsPattern}]`,'g'), '_');
     }
     get objectNameFixedShort(): string {
         return StringFunctions.removeAllButAlfaNumeric(this.objectNameFixed);
     }
     get extendedObjectNameFixed(): string {
         let extendedObjectName = this.extendedObjectName.trim().toString();
-
-        return extendedObjectName.replace(/[^ 0-9a-zA-Z._&-]/g, '_');
+        return extendedObjectName;
+    }
+    get extendedObjectNameFixedForFileName(): string {
+        let extendedObjectName = this.extendedObjectNameFixed;
+        return extendedObjectName.replace(new RegExp(`[${this.prohibitedFilenameCharsPattern}]`,'g'), '_');
     }
     get extendedObjectNameFixedShort(): string {
         return StringFunctions.removeAllButAlfaNumeric(this.extendedObjectNameFixed);
     }
     get NAVObjectTextFixed(): string {
         let NAVObjectTextFixed = this.NAVObjectText;
-        NAVObjectTextFixed = this.updateObjectNameInObjectText(NAVObjectTextFixed);
+        NAVObjectTextFixed = this.updateObjectNameInObjectText(NAVObjectTextFixed); 
         NAVObjectTextFixed = this.AddPrefixToActions(NAVObjectTextFixed);
         NAVObjectTextFixed = this.AddPrefixToFields(NAVObjectTextFixed);
 
@@ -67,9 +86,9 @@ export class NAVObject {
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectTypeShort>', this.objectTypeShort);
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectTypeShortUpper>', this.objectTypeShort.toUpperCase());
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectId>', this.objectId);
-        objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectName>', this.objectNameFixed);
+        objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectName>', this.objectNameFixedForFileName);
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<ObjectNameShort>', this.objectNameFixedShort);
-        objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<BaseName>', this.extendedObjectNameFixed);
+        objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<BaseName>', this.extendedObjectNameFixedForFileName);
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<BaseNameShort>', this.extendedObjectNameFixedShort);
         objectFileNameFixed = StringFunctions.replaceAll(objectFileNameFixed, '<BaseId>', this.extendedObjectId);
 
@@ -99,6 +118,8 @@ export class NAVObject {
         this.objectName = '';
         this.extendedObjectName = '';
         this.extendedObjectId = '';
+        var ObjectNamePattern = '"[\\x20\\x21\\x23-\\x7E\\x80-\\xFE]*"' // All printable ASCII characters except "
+        var ObjectNameNoQuotesPattern = '[\\w]*';
 
         if (!ObjectTypeArr) { return null }
 
@@ -112,7 +133,7 @@ export class NAVObject {
                 case 'table':
                 case 'xmlport': {
 
-                    var patternObject = new RegExp('(\\w+)( +[0-9]+)( +"?[ a-zA-Z0-9._/&-]+"?)');
+                    var patternObject = new RegExp(`(\\w+) +([0-9]+) +(${ObjectNamePattern}|${ObjectNameNoQuotesPattern})`);
                     let currObject = this.NAVObjectText.match(patternObject);
 
                     this.objectType = currObject[1];
@@ -125,9 +146,8 @@ export class NAVObject {
                 }
                 case 'pageextension':
                 case 'tableextension': {
-                    var patternObject = new RegExp('(\\w+)( +[0-9]+)( +"?[ a-zA-Z0-9._&-]+\\/?[ a-zA-Z0-9._&-]+"?) +extends( +"?[ a-zA-Z0-9._&-]+\\/?[ a-zA-Z0-9._&-]+"?) ?(\\/\\/+ *)?([0-9]+)?');
+                    var patternObject = new RegExp(`(\\w+) +([0-9]+) +(${ObjectNamePattern}|${ObjectNameNoQuotesPattern}) +extends +(${ObjectNamePattern}|${ObjectNameNoQuotesPattern})\\s*(\\/\\/\\s*)?([0-9]+)?`);
                     let currObject = this.NAVObjectText.match(patternObject);
-
                     this.objectType = currObject[1];
                     this.objectId = currObject[2];
                     this.objectName = currObject[3];
@@ -207,13 +227,19 @@ export class NAVObject {
 
     private updateObjectNameInObjectText(objectText: string): string {
         if (!this.objectName) { return objectText };
-
+        var escapedObjectName = this.escapeRegExp(this.objectName);
+        var searchPattern = RegExp(escapedObjectName);
         if (objectText.indexOf("\"" + this.objectName + "\"") >= 0) {
-            return objectText.replace(this.objectName, this.objectNameFixed);
+            return objectText.replace(searchPattern, this.objectNameFixed);
         } else {
-            return objectText.replace(this.objectName, "\"" + this.objectNameFixed + "\"");
+            return objectText.replace(searchPattern, "\"" + this.objectNameFixed + "\"");
         }
     }
+
+    private escapeRegExp(str) {
+        // Ref. https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+        return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+      }
 
     private AddPrefixToActions(objectText: string): string {
         this.objectActions.forEach(action => {

--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -4,6 +4,7 @@ import { StringFunctions } from './StringFunctions'
 import { DynamicsNAV } from './DynamicsNAV';
 import * as fs from 'fs';
 import * as path from 'path'
+import { error } from 'util';
 
 export class NAVObject {
     public objectFileName: string;
@@ -118,7 +119,7 @@ export class NAVObject {
         this.objectName = '';
         this.extendedObjectName = '';
         this.extendedObjectId = '';
-        var ObjectNamePattern = '"[\\x20\\x21\\x23-\\x7E\\x80-\\xFE]*"' // All printable ASCII characters except "
+        var ObjectNamePattern = '"[^"]*"' // All characters except "
         var ObjectNameNoQuotesPattern = '[\\w]*';
 
         if (!ObjectTypeArr) { return null }
@@ -135,6 +136,9 @@ export class NAVObject {
 
                     var patternObject = new RegExp(`(\\w+) +([0-9]+) +(${ObjectNamePattern}|${ObjectNameNoQuotesPattern})`);
                     let currObject = this.NAVObjectText.match(patternObject);
+                    if (currObject == null) {
+                        throw new Error(`File '${this.objectFileName}' does not have valid object name. Maybe it got double quotes (") in the object name?`)
+                    }
 
                     this.objectType = currObject[1];
                     this.objectId = currObject[2];
@@ -148,6 +152,9 @@ export class NAVObject {
                 case 'tableextension': {
                     var patternObject = new RegExp(`(\\w+) +([0-9]+) +(${ObjectNamePattern}|${ObjectNameNoQuotesPattern}) +extends +(${ObjectNamePattern}|${ObjectNameNoQuotesPattern})\\s*(\\/\\/\\s*)?([0-9]+)?`);
                     let currObject = this.NAVObjectText.match(patternObject);
+                    if (currObject == null) {
+                       throw new Error(`File '${this.objectFileName}' does not have valid object names. Maybe it got double quotes (") in the object name?`)
+                    }
                     this.objectType = currObject[1];
                     this.objectId = currObject[2];
                     this.objectName = currObject[3];

--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -4,7 +4,6 @@ import { StringFunctions } from './StringFunctions'
 import { DynamicsNAV } from './DynamicsNAV';
 import * as fs from 'fs';
 import * as path from 'path'
-import { error } from 'util';
 
 export class NAVObject {
     public objectFileName: string;

--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -133,10 +133,13 @@ export class NAVObject {
                 case 'table':
                 case 'xmlport': {
 
-                    var patternObject = new RegExp(`(\\w+) +([0-9]+) +(${ObjectNamePattern}|${ObjectNameNoQuotesPattern})`);
+                    var patternObject = new RegExp(`(\\w+) +([0-9]+) +(${ObjectNamePattern}|${ObjectNameNoQuotesPattern})([^"\n]*"[^"\n]*)?`);
                     let currObject = this.NAVObjectText.match(patternObject);
                     if (currObject == null) {
                         throw new Error(`File '${this.objectFileName}' does not have valid object name. Maybe it got double quotes (") in the object name?`)
+                    }
+                    if (currObject[4] != null) {
+                        throw new Error(`File '${this.objectFileName}' does not have valid object name, it has too many double quotes (")`)
                     }
 
                     this.objectType = currObject[1];

--- a/src/WorkspaceFiles.ts
+++ b/src/WorkspaceFiles.ts
@@ -53,15 +53,15 @@ export class WorkspaceFiles {
 
         let fixedname = navObject.objectFileNameFixed
         if (navObject.objectFileName && navObject.objectFileName != '' && fixedname && fixedname != '') {
-            if (path.join(vscode.workspace.getWorkspaceFolder(fileName).uri.fsPath, navObject.objectType, navObject.objectFileName) == fileName.fsPath) {
+
+            let objectFolder = path.join(vscode.workspace.getWorkspaceFolder(fileName).uri.fsPath, this.getDestinationFolder(navObject, mySettings));
+            let objectTypeFolder = path.join(objectFolder, this.getObjectTypeFolder(navObject));
+            let destinationFileName = path.join(objectTypeFolder, fixedname);
+
+            if (destinationFileName == fileName.fsPath) {
                 console.log('paths are the same.');
                 return fileName.fsPath;
             } else {
-                let destionationFileName = path.join(vscode.workspace.getWorkspaceFolder(fileName).uri.fsPath, this.getDestinationFolder(navObject, mySettings));
-
-                let objectFolder = path.join(vscode.workspace.getWorkspaceFolder(fileName).uri.fsPath, this.getDestinationFolder(navObject, mySettings));
-                let objectTypeFolder = path.join(objectFolder, this.getObjectTypeFolder(navObject));
-                let destinationFileName = path.join(objectTypeFolder, fixedname);
 
                 (!fs.existsSync(objectFolder)) ? fs.mkdirSync(objectFolder) : '';
                 (!fs.existsSync(objectTypeFolder)) ? fs.mkdirSync(objectTypeFolder) : '';

--- a/src/WorkspaceFiles.ts
+++ b/src/WorkspaceFiles.ts
@@ -81,12 +81,22 @@ export class WorkspaceFiles {
         vscode.workspace.saveAll();
 
         this.getAlFilesFromCurrentWorkspace().then(Files => {
+            let totalFileCount = 0;
+            let renamedFileCount = 0;
+            try {
+                Files.forEach(file => {
+                    console.log(file.fsPath);
+                    totalFileCount++;
+                    let newFilename = this.RenameFile(file);
+                    if (file.fsPath != newFilename) {
+                        renamedFileCount++;
+                    }
 
-            Files.forEach(file => {
-                console.log(file.fsPath);
-
-                this.RenameFile(file);
-            })
+                })
+                vscode.window.showInformationMessage(`${renamedFileCount} files out of ${totalFileCount} was renamed`)
+            } catch (error) {
+                vscode.window.showErrorMessage(error.message);
+            }
         });
     }
 
@@ -94,12 +104,24 @@ export class WorkspaceFiles {
 
     static ReorganizeAllFiles() {
         vscode.workspace.saveAll();
-
         this.getAlFilesFromCurrentWorkspace().then(Files => {
-            Files.forEach(file => {
-                this.ReorganizeFile(file);
-            })
-        });
+            try {
+                let totalFileCount = 0;
+                let renamedFileCount = 0;
+                Files.forEach(file => {
+                    totalFileCount++;
+                    let newFilename = this.ReorganizeFile(file);
+                    if (file.fsPath != newFilename) {
+                        renamedFileCount++;
+                    }
+
+                })
+                vscode.window.showInformationMessage(`${renamedFileCount} files out of ${totalFileCount} was reorganized`)
+            } catch (error) {
+                vscode.window.showErrorMessage(error.message);
+            }
+        }
+        );
     }
 
 

--- a/src/test/NAVObject.test.ts
+++ b/src/test/NAVObject.test.ts
@@ -362,4 +362,22 @@ suite("NAVObject Tests", () => {
         assert.equal(navObject.objectFileNameFixed.indexOf('*'), -1); //does not contain slash
 
     })
+
+
+    test("Filename - Rename PageExtension with double qoutes in object name", () => {
+        let testSettings = Settings.GetConfigSettings(null)
+        testSettings[Settings.FileNamePatternExtensions] = '<BaseName>_<ObjectName>.PageExt.al'
+
+        let navTestObject = NAVTestObjectLibrary.getPageExtensionWithQuotesInObjectName();
+        try {
+            let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName);    
+            throw new Error('Object Name parsing accepted double quotes in name.');
+        } catch (error) {
+            assert.equal(error.message,`File '${navTestObject.ObjectFileName}' does not have valid object names. Maybe it got double quotes (") in the object name?`)
+            
+        }
+        
+
+    })
+
 });

--- a/src/test/NAVObject.test.ts
+++ b/src/test/NAVObject.test.ts
@@ -380,4 +380,20 @@ suite("NAVObject Tests", () => {
 
     })
 
+
+    test("Filename - Rename Page with double qoutes in object name", () => {
+        let testSettings = Settings.GetConfigSettings(null)
+        testSettings[Settings.FileNamePatternExtensions] = '<BaseName>_<ObjectName>.al'
+
+        let navTestObject = NAVTestObjectLibrary.getPageWithQuotesInObjectName();
+        try {
+            let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName);    
+            throw new Error('Object Name parsing accepted double quotes in name.');
+        } catch (error) {
+            assert.equal(error.message,`File '${navTestObject.ObjectFileName}' does not have valid object name, it has too many double quotes (")`)
+            
+        }
+        
+
+    })
 });

--- a/src/test/NAVObject.test.ts
+++ b/src/test/NAVObject.test.ts
@@ -343,10 +343,13 @@ suite("NAVObject Tests", () => {
 
     test("Filename - Rename PageExtension with WeirdChars", () => {
         let testSettings = Settings.GetConfigSettings(null)
-        testSettings[Settings.FileNamePatternExtensions] = '<BaseName>.PageExt.al'
+        testSettings[Settings.FileNamePatternExtensions] = '<BaseName>_<ObjectName>.PageExt.al'
 
         let navTestObject = NAVTestObjectLibrary.getPageExtensionWithWeirdChars();
         let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName);
+
+        assert.notEqual(navObject.objectFileNameFixed.indexOf('µ'),-1); //does still contain µ
+        assert.notEqual(navObject.objectFileNameFixed.indexOf('åäö'),-1); //does still contain åäö
 
         assert.equal(navObject.objectFileNameFixed.indexOf('<'), -1); //does not contain slash
         assert.equal(navObject.objectFileNameFixed.indexOf('>'), -1); //does not contain slash

--- a/src/test/NAVTestObjectLibrary.ts
+++ b/src/test/NAVTestObjectLibrary.ts
@@ -180,7 +180,7 @@ export function getPageExtensionWithWeirdChars(): NAVTestObject {
     let object = new NAVTestObject;
 
     object.ObjectFileName = 'Pag50102.justAName.al'
-    object.ObjectText = `pageextension 50102 "S<a>l:es/p\\e|rµ?s*on/Ext" extends "Salespersons/Purchasers" //14
+    object.ObjectText = `pageextension 50102 "S<a>l:es/p\\e|rµ?s*oåäön/Ext" extends "Salespersons/Purchasers" //14
 {
     layout
     {

--- a/src/test/NAVTestObjectLibrary.ts
+++ b/src/test/NAVTestObjectLibrary.ts
@@ -214,6 +214,24 @@ export function getPageExtensionWithQuotesInObjectName(): NAVTestObject {
     `
     return object;
 }
+export function getPageWithQuotesInObjectName(): NAVTestObject {
+    let object = new NAVTestObject;
+
+    object.ObjectFileName = 'Pag50103.justANameWithQuotes.al'
+    object.ObjectText = `page 50103 "S<a>l:es/p\\e"|rµ?s"*oåäön/"
+{
+    layout
+    {
+        ////
+    }
+
+    actions
+    {
+    }
+}
+    `
+    return object;
+}
 export function getPageExtensionWithAmpersandInFileName(): NAVTestObject {
     let object = new NAVTestObject;
 

--- a/src/test/NAVTestObjectLibrary.ts
+++ b/src/test/NAVTestObjectLibrary.ts
@@ -194,6 +194,26 @@ export function getPageExtensionWithWeirdChars(): NAVTestObject {
     `
     return object;
 }
+
+
+export function getPageExtensionWithQuotesInObjectName(): NAVTestObject {
+    let object = new NAVTestObject;
+
+    object.ObjectFileName = 'Pag50102.justANameWithQuotes.al'
+    object.ObjectText = `pageextension 50102 "S<a>l:es/p\\e"|rµ?s"*oåäön/Ext" extends "Salespersons/Purchasers" //14
+{
+    layout
+    {
+        ////
+    }
+
+    actions
+    {
+    }
+}
+    `
+    return object;
+}
 export function getPageExtensionWithAmpersandInFileName(): NAVTestObject {
     let object = new NAVTestObject;
 


### PR DESCRIPTION
It's a challenge to create a regex that matches all possible names of objects. 
Now I've added all printable ASCII characters except ". That should work for files converted from C/AL, but could still miss some Unicode characters if used... Don't really know how to solve that properly.

Anyway, I added a bit to your new test to also check that some characters as µ and åäö still exists after fixing filename.

The test runs fine for me now.

What do you think?