### PR TITLE
Split field name and source in tpagefield snippet

### DIFF
--- a/snippets/fromAlExtension/page.json
+++ b/snippets/fromAlExtension/page.json
@@ -46,7 +46,7 @@
     "Snippet: Page Field": {
         "prefix": "tpagefield (CRS)",
         "body": [
-            "field(${1:MyField; FieldSource})",
+            "field(${1:MyField}; ${2:FieldSource})",
             "{",
             "\tApplicationArea = ${3|All,Basic,Suite,Advanced|};",
             "}",


### PR DESCRIPTION
Currently they are part of the same selection, while in the AL extension snippets they are separate. I don't see an upside to having them combined (more often than not you'll have to manually re-type the semicolon), so this splits them again to stay consistent with the base extension.