### PR TITLE
Remove brackets from ttrigger placeholder

### DIFF
--- a/snippets/fromAlExtension/al.json
+++ b/snippets/fromAlExtension/al.json
@@ -2,7 +2,7 @@
     "Snippet: Trigger": {
         "prefix": "ttrigger (CRS)",
         "body": [
-            "trigger ${1:OnWhat()}",
+            "trigger ${1:OnWhat}()",
             "begin",
             "\t$0",
             "end;"


### PR DESCRIPTION
who wants to create a trigger without brackets?